### PR TITLE
Improve bookmark folder logic

### DIFF
--- a/src/components/BookmarkNode.ts
+++ b/src/components/BookmarkNode.ts
@@ -7,8 +7,7 @@ import { Link, LinkComponent, LinkProps } from './Link';
 type FolderPopupComponent = HTMLDivElement;
 
 const CLOSE_DELAY_MS = 600;
-
-const emptyPopupView = h`<div class=empty>(empty)</div>`;
+let emptyPopupView;
 
 const folderPopupView = create('div');
 folderPopupView.className = 'sf';
@@ -45,7 +44,7 @@ function FolderPopup(
   }
 
   if (!children.length) {
-    append(emptyPopupView, root);
+    append((emptyPopupView ??= h`<div class=empty>(empty)</div>`), root);
   } else {
     children.forEach((item) => {
       append(BookmarkNode(item), root);

--- a/src/css/newtab.xcss
+++ b/src/css/newtab.xcss
@@ -166,6 +166,11 @@ button {
   }
 }
 
+.empty {
+  padding: 0 13px;
+  color: var(--c3);
+}
+
 // FIXME: Show this in the folder component
 .caret {
   float: right;


### PR DESCRIPTION
Fixes #1122 and #1123 

- Rename "subfolder" to "folder popup"
- Increase close timeout delay to 600ms
- Close other popups on the same level when opening a new folder popup
- Show "(empty)" in empty folder popups
- Golfing to reduce output code size