### PR TITLE
Fix bookmark popup positioning

### DIFF
--- a/src/css/newtab.xcss
+++ b/src/css/newtab.xcss
@@ -178,9 +178,7 @@ button {
   overflow-y: auto;
   background: var(--c2);
   box-shadow: var(--s);
-
-  // FIXME: Height needs to be calculated depending on the folder top position
-  max-height: calc(100vh - 42px);
+  z-index: 1;
 
   a,
   // folder


### PR DESCRIPTION
Fixes #1121

- Initially render bookmark folder popup with simple positioning
- Adjust position of the popup after it's been attached to the DOM when we have size data

> Note: Although this basically works, it's still buggy when there's scrollbars in the folder popup. This is enough to get by for now though.