### PR TITLE
Handle `mouseenter`/`mouseleave` events using a synthetic event approach

### DIFF
--- a/src/components/BookmarkBar.ts
+++ b/src/components/BookmarkBar.ts
@@ -111,8 +111,8 @@ export function BookmarkBar(): BookmarkBarComponent {
     window.onresize = resize;
   });
 
-  root.onmouseover = syntheticMouseEnterLeave;
-  root.onmouseout = syntheticMouseEnterLeave;
+  // eslint-disable-next-line no-multi-assign
+  root.onmouseover = root.onmouseout = syntheticMouseEnterLeave;
 
   return root;
 }

--- a/src/components/BookmarkBar.ts
+++ b/src/components/BookmarkBar.ts
@@ -16,8 +16,8 @@ declare global {
 // https://github.com/maxmilton/stage1/blob/495ccf98af62fc1a1360bbf23de1ab2712eb586c/src/events.ts#L3
 const syntheticMouseEnterLeave = (event: MouseEvent) => {
   const eventKey = '__' + event.type;
-  // undefined when mouse moves in from outside the viewport
-  const related = event.relatedTarget as Node | undefined;
+  // null when mouse moves from/to outside the viewport
+  const related = event.relatedTarget as Node | null;
   let node = event.target as Node | null;
 
   while (node) {

--- a/src/components/BookmarkBar.ts
+++ b/src/components/BookmarkBar.ts
@@ -4,34 +4,18 @@ import { BookmarkNode, Folder, FolderProps } from './BookmarkNode';
 
 declare global {
   interface HTMLElement {
-    /** BookmarkBar synthetic `mouseenter` event handler. */
+    /**
+     * BookmarkBar synthetic `mouseenter` event handler. Note the property is
+     * named `__mouseover` but it actually works like `mouseenter`.
+     */
     __mouseover(event: MouseEvent): void;
-    /** BookmarkBar synthetic `mouseleave` event handler. */
+    /**
+     * BookmarkBar synthetic `mouseleave` event handler. Note the property is
+     * named `__mouseout` but it actually works like `mouseleave`.
+     */
     __mouseout(event: MouseEvent): void;
   }
 }
-
-// XXX: Similar to stage1 synthetic event logic but does not stop propagating
-// once an event handler is called + extra relatedTarget checks
-// https://github.com/maxmilton/stage1/blob/495ccf98af62fc1a1360bbf23de1ab2712eb586c/src/events.ts#L3
-const syntheticMouseEnterLeave = (event: MouseEvent) => {
-  const eventKey = '__' + event.type;
-  // null when mouse moves from/to outside the viewport
-  const related = event.relatedTarget as Node | null;
-  let node = event.target as Node | null;
-
-  while (node) {
-    // @ts-expect-error - string indexing dom is unavoidable
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const eventHandler = node[eventKey];
-
-    if (eventHandler && (!related || !node.contains(related))) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      eventHandler(event);
-    }
-    node = node.parentNode;
-  }
-};
 
 type BookmarkBarComponent = HTMLDivElement;
 
@@ -111,8 +95,29 @@ export function BookmarkBar(): BookmarkBarComponent {
     window.onresize = resize;
   });
 
+  // Synthetic `mouseenter` and `mouseleave` event handler
+  // XXX: Similar to stage1 synthetic event logic but does not stop propagating
+  // once an event handler is called + extra relatedTarget checks
+  // https://github.com/maxmilton/stage1/blob/495ccf98af62fc1a1360bbf23de1ab2712eb586c/src/events.ts#L3
   // eslint-disable-next-line no-multi-assign
-  root.onmouseover = root.onmouseout = syntheticMouseEnterLeave;
+  root.onmouseover = root.onmouseout = (event) => {
+    const eventKey = '__' + event.type;
+    // null when mouse moves from/to outside the viewport
+    const related = event.relatedTarget as Node | null;
+    let node = event.target as Node | null;
+
+    while (node) {
+      // @ts-expect-error - string indexing dom is unavoidable
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const eventHandler = node[eventKey];
+
+      if (eventHandler && (!related || !node.contains(related))) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        eventHandler(event);
+      }
+      node = node.parentNode;
+    }
+  };
 
   return root;
 }

--- a/src/components/BookmarkNode.ts
+++ b/src/components/BookmarkNode.ts
@@ -93,15 +93,12 @@ export function Folder(item: FolderProps): FolderComponent {
 
   root.closePopup = () => {
     if (popup) {
-      // eslint-disable-next-line no-multi-assign
-      popup.onmouseenter = popup.onmouseleave = null;
-
       popup.remove();
       popup = null;
     }
   };
 
-  root.onmouseenter = () => {
+  root.__mouseover = () => {
     clearTimer();
 
     if (!popup) {
@@ -119,15 +116,15 @@ export function Folder(item: FolderProps): FolderComponent {
         parent.id === 'b',
       );
 
-      popup.onmouseenter = clearTimer;
-      popup.onmouseleave = resetTimer;
+      popup.__mouseover = clearTimer;
+      popup.__mouseout = resetTimer;
 
       append(popup, root);
       popup.adjustPosition();
     }
   };
 
-  root.onmouseleave = resetTimer;
+  root.__mouseout = resetTimer;
 
   return root;
 }


### PR DESCRIPTION
Reduces the number of native event listeners down to 6 + 3 `chrome.tabs` listeners.