### PR TITLE
chore: Refactor build + update to new esbuild API

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -18,6 +18,102 @@ const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
 const dir = path.resolve(); // == __dirname
 
+/**
+ * Generate minified CSS from XCSS source.
+ *
+ * @param {string} src
+ * @param {string} from
+ */
+function compileCSS(src, from) {
+  const compiled = xcss.compile(src, {
+    from,
+    map: false,
+  });
+
+  for (const warning of compiled.warnings) {
+    console.error('XCSS WARNING:', warning.message);
+
+    if (warning.file) {
+      console.log(
+        `  at ${[warning.file, warning.line, warning.column]
+          .filter((x) => x != null)
+          .join(':')}`,
+      );
+    }
+  }
+
+  const minified = lightningcss.transform({
+    filename: from,
+    code: Buffer.from(compiled.css),
+    minify: !dev,
+    sourceMap: false,
+    targets: {
+      // eslint-disable-next-line no-bitwise
+      chrome: 110 << 16,
+    },
+  });
+
+  for (const warning of minified.warnings) {
+    console.error('CSS WARNING:', warning.message);
+  }
+
+  return minified.code.toString();
+}
+
+/**
+ * Construct a HTML file and save it to disk.
+ *
+ * @param {string} pageName
+ * @param {string} stylePath
+ */
+async function makeHTML(pageName, stylePath) {
+  const styleSrc = await fs.readFile(path.join(dir, stylePath), 'utf8');
+  const css = compileCSS(styleSrc, stylePath);
+  const template = `<!doctype html>
+<meta charset=utf-8>
+<title>New Tab</title>
+<link href=${pageName}.css rel=stylesheet>
+<script src=${pageName}.js async></script>`;
+
+  await fs.writeFile(path.join(dir, 'dist', `${pageName}.css`), css);
+  await fs.writeFile(path.join(dir, 'dist', `${pageName}.html`), template);
+}
+
+await makeHTML('newtab', 'src/css/newtab.xcss');
+await makeHTML('settings', 'src/css/settings.xcss');
+
+// Extension manifest
+await fs.writeFile(
+  path.join(dir, 'dist', 'manifest.json'),
+  JSON.stringify(manifest),
+);
+
+/**
+ * Compile all themes, combine into a single JSON file, and save it to disk.
+ */
+async function makeThemes() {
+  const themesDir = path.resolve('.', 'src/css/themes');
+  /** @type {Record<string, string>} */
+  const themesData = {};
+  const themes = await fs.readdir(themesDir);
+
+  await Promise.all(
+    themes.map((theme) => fs.readFile(path.join(themesDir, theme), 'utf8').then((src) => {
+      themesData[path.basename(theme, '.xcss')] = compileCSS(src, theme);
+    })),
+  );
+
+  await fs.writeFile(
+    path.join(dir, 'dist', 'themes.json'),
+    JSON.stringify(themesData),
+  );
+}
+
+const t0 = performance.now();
+await makeThemes();
+const t1 = performance.now();
+console.log('\ndist/themes.json done in', (t1 - t0).toFixed(2), 'ms\n');
+
 /** @type {esbuild.Plugin} */
 const analyzeMeta = {
   name: 'analyze-meta',
@@ -60,11 +156,12 @@ const minifyJS = {
 };
 
 // New Tab & Settings apps
-await esbuild.build({
+/** @type {esbuild.BuildOptions} */
+const esbuildOptions1 = {
   entryPoints: ['src/newtab.ts', 'src/settings.ts'],
   outdir: 'dist',
   platform: 'browser',
-  target: ['chrome104'],
+  target: ['chrome110'],
   format: 'esm',
   define: { 'process.env.NODE_ENV': JSON.stringify(mode) },
   plugins: [minifyTemplates(), minifyJS, writeFiles(), analyzeMeta],
@@ -73,16 +170,16 @@ await esbuild.build({
   mangleProps: /_refs|collect|adjustPosition|closePopup/,
   sourcemap: dev,
   banner: { js: '"use strict";' },
-  watch: dev,
   write: dev,
   metafile: !dev && process.stdout.isTTY,
   logLevel: 'debug',
   // XXX: Comment out to keep performance markers in non-dev builds for debugging
   pure: ['performance.mark', 'performance.measure'],
-});
+};
 
 // Background service worker script
-await esbuild.build({
+/** @type {esbuild.BuildOptions} */
+const esbuildOptions2 = {
   entryPoints: ['src/sw.ts'],
   outdir: 'dist',
   format: 'esm',
@@ -91,95 +188,13 @@ await esbuild.build({
   minify: !dev,
   metafile: !dev && process.stdout.isTTY,
   logLevel: 'debug',
-});
+};
 
-/**
- * Generate minified CSS from XCSS source.
- *
- * @param {string} src
- * @param {string} from
- */
-function compileCSS(src, from) {
-  const compiled = xcss.compile(src, {
-    from,
-    map: false,
-  });
-
-  for (const warning of compiled.warnings) {
-    console.error('XCSS WARNING:', warning.message);
-
-    if (warning.file) {
-      console.log(
-        `  at ${[warning.file, warning.line, warning.column]
-          .filter(Boolean)
-          .join(':')}`,
-      );
-    }
-  }
-
-  const minified = lightningcss.transform({
-    filename: from,
-    code: Buffer.from(compiled.css),
-    minify: true,
-    sourceMap: dev,
-    targets: {
-      // eslint-disable-next-line no-bitwise
-      chrome: 104 << 16,
-    },
-  });
-
-  for (const warning of minified.warnings) {
-    console.error('CSS WARNING:', warning.message);
-  }
-
-  return minified.code.toString();
+if (dev) {
+  const context1 = await esbuild.context(esbuildOptions1);
+  const context2 = await esbuild.context(esbuildOptions2);
+  await Promise.all([context1.watch(), context2.watch()]);
+} else {
+  await esbuild.build(esbuildOptions1);
+  await esbuild.build(esbuildOptions2);
 }
-
-/**
- * Construct a HTML file and save it to disk.
- *
- * @param {string} pageName
- * @param {string} stylePath
- */
-async function makeHTML(pageName, stylePath) {
-  const styleSrc = await fs.readFile(path.join(dir, stylePath), 'utf8');
-  const css = compileCSS(styleSrc, stylePath);
-  const template = `<!doctype html>
-<meta charset=utf-8>
-<title>New Tab</title>
-<link href=${pageName}.css rel=stylesheet>
-<script src=${pageName}.js async></script>`;
-
-  await fs.writeFile(path.join(dir, 'dist', `${pageName}.css`), css);
-  await fs.writeFile(path.join(dir, 'dist', `${pageName}.html`), template);
-}
-
-await makeHTML('newtab', 'src/css/newtab.xcss');
-await makeHTML('settings', 'src/css/settings.xcss');
-
-// Extension manifest
-await fs.writeFile(
-  path.join(dir, 'dist', 'manifest.json'),
-  JSON.stringify(manifest),
-);
-
-const t0 = performance.now();
-
-const themesDir = path.resolve('.', 'src/css/themes');
-/** @type {Record<string, string>} */
-const themesData = {};
-const themes = await fs.readdir(themesDir);
-
-await Promise.all(
-  themes.map((theme) => fs.readFile(path.join(themesDir, theme), 'utf8').then((src) => {
-    themesData[path.basename(theme, '.xcss')] = compileCSS(src, theme);
-  })),
-);
-
-await fs.writeFile(
-  path.join(dir, 'dist', 'themes.json'),
-  JSON.stringify(themesData),
-);
-
-const t1 = performance.now();
-console.log('\ndist/themes.json done in', (t1 - t0).toFixed(2), 'ms\n');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm run prebuild && NODE_ENV=production node build.mjs",
-    "dev": "NODE_ENV=development node build.mjs",
+    "dev": "pnpm run prebuild && NODE_ENV=development node build.mjs",
     "lint": "pnpm run lint:css && pnpm run lint:js && pnpm run lint:ts",
     "lint:css": "stylelint --ignore-path .gitignore '**/*.{css,xcss}'",
     "lint:js": "eslint --ignore-path .gitignore --ext .cjs,.js,.mjs,.ts .",
@@ -30,7 +30,7 @@
     "@typescript-eslint/parser": "5.51.0",
     "c8": "7.12.0",
     "ekscss": "0.0.13",
-    "esbuild": "0.16.17",
+    "esbuild": "0.17.6",
     "esbuild-minify-templates": "0.10.0",
     "eslint": "8.33.0",
     "eslint-config-airbnb-base": "15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   '@typescript-eslint/parser': 5.51.0
   c8: 7.12.0
   ekscss: 0.0.13
-  esbuild: 0.16.17
+  esbuild: 0.17.6
   esbuild-minify-templates: 0.10.0
   eslint: 8.33.0
   eslint-config-airbnb-base: 15.0.0
@@ -40,8 +40,8 @@ devDependencies:
   '@typescript-eslint/parser': 5.51.0_4vsywjlpuriuw3tl5oq6zy5a64
   c8: 7.12.0
   ekscss: 0.0.13
-  esbuild: 0.16.17
-  esbuild-minify-templates: 0.10.0_esbuild@0.16.17
+  esbuild: 0.17.6
+  esbuild-minify-templates: 0.10.0_esbuild@0.17.6
   eslint: 8.33.0
   eslint-config-airbnb-base: 15.0.0_ohdts44xlqyeyrlje4qnefqeay
   eslint-config-airbnb-typescript: 17.0.0_hr4vvfxda2sq3vvto4fmjggsgy
@@ -115,8 +115,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm/0.16.17:
-    resolution: {integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==}
+  /@esbuild/android-arm/0.17.6:
+    resolution: {integrity: sha512-bSC9YVUjADDy1gae8RrioINU6e1lCkg3VGVwm0QQ2E1CWcC4gnMce9+B6RpxuSsrsXsk1yojn7sp1fnG8erE2g==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -124,8 +124,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm64/0.16.17:
-    resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
+  /@esbuild/android-arm64/0.17.6:
+    resolution: {integrity: sha512-YnYSCceN/dUzUr5kdtUzB+wZprCafuD89Hs0Aqv9QSdwhYQybhXTaSTcrl6X/aWThn1a/j0eEpUBGOE7269REg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -133,8 +133,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64/0.16.17:
-    resolution: {integrity: sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==}
+  /@esbuild/android-x64/0.17.6:
+    resolution: {integrity: sha512-MVcYcgSO7pfu/x34uX9u2QIZHmXAB7dEiLQC5bBl5Ryqtpj9lT2sg3gNDEsrPEmimSJW2FXIaxqSQ501YLDsZQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -142,8 +142,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64/0.16.17:
-    resolution: {integrity: sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==}
+  /@esbuild/darwin-arm64/0.17.6:
+    resolution: {integrity: sha512-bsDRvlbKMQMt6Wl08nHtFz++yoZHsyTOxnjfB2Q95gato+Yi4WnRl13oC2/PJJA9yLCoRv9gqT/EYX0/zDsyMA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -151,8 +151,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64/0.16.17:
-    resolution: {integrity: sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==}
+  /@esbuild/darwin-x64/0.17.6:
+    resolution: {integrity: sha512-xh2A5oPrYRfMFz74QXIQTQo8uA+hYzGWJFoeTE8EvoZGHb+idyV4ATaukaUvnnxJiauhs/fPx3vYhU4wiGfosg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -160,8 +160,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64/0.16.17:
-    resolution: {integrity: sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==}
+  /@esbuild/freebsd-arm64/0.17.6:
+    resolution: {integrity: sha512-EnUwjRc1inT4ccZh4pB3v1cIhohE2S4YXlt1OvI7sw/+pD+dIE4smwekZlEPIwY6PhU6oDWwITrQQm5S2/iZgg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -169,8 +169,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64/0.16.17:
-    resolution: {integrity: sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==}
+  /@esbuild/freebsd-x64/0.17.6:
+    resolution: {integrity: sha512-Uh3HLWGzH6FwpviUcLMKPCbZUAFzv67Wj5MTwK6jn89b576SR2IbEp+tqUHTr8DIl0iDmBAf51MVaP7pw6PY5Q==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -178,8 +178,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm/0.16.17:
-    resolution: {integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==}
+  /@esbuild/linux-arm/0.17.6:
+    resolution: {integrity: sha512-7YdGiurNt7lqO0Bf/U9/arrPWPqdPqcV6JCZda4LZgEn+PTQ5SMEI4MGR52Bfn3+d6bNEGcWFzlIxiQdS48YUw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -187,8 +187,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64/0.16.17:
-    resolution: {integrity: sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==}
+  /@esbuild/linux-arm64/0.17.6:
+    resolution: {integrity: sha512-bUR58IFOMJX523aDVozswnlp5yry7+0cRLCXDsxnUeQYJik1DukMY+apBsLOZJblpH+K7ox7YrKrHmJoWqVR9w==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -196,8 +196,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32/0.16.17:
-    resolution: {integrity: sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==}
+  /@esbuild/linux-ia32/0.17.6:
+    resolution: {integrity: sha512-ujp8uoQCM9FRcbDfkqECoARsLnLfCUhKARTP56TFPog8ie9JG83D5GVKjQ6yVrEVdMie1djH86fm98eY3quQkQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -214,8 +214,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64/0.16.17:
-    resolution: {integrity: sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==}
+  /@esbuild/linux-loong64/0.17.6:
+    resolution: {integrity: sha512-y2NX1+X/Nt+izj9bLoiaYB9YXT/LoaQFYvCkVD77G/4F+/yuVXYCWz4SE9yr5CBMbOxOfBcy/xFL4LlOeNlzYQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -223,8 +223,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el/0.16.17:
-    resolution: {integrity: sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==}
+  /@esbuild/linux-mips64el/0.17.6:
+    resolution: {integrity: sha512-09AXKB1HDOzXD+j3FdXCiL/MWmZP0Ex9eR8DLMBVcHorrWJxWmY8Nms2Nm41iRM64WVx7bA/JVHMv081iP2kUA==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -232,8 +232,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64/0.16.17:
-    resolution: {integrity: sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==}
+  /@esbuild/linux-ppc64/0.17.6:
+    resolution: {integrity: sha512-AmLhMzkM8JuqTIOhxnX4ubh0XWJIznEynRnZAVdA2mMKE6FAfwT2TWKTwdqMG+qEaeyDPtfNoZRpJbD4ZBv0Tg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -241,8 +241,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64/0.16.17:
-    resolution: {integrity: sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==}
+  /@esbuild/linux-riscv64/0.17.6:
+    resolution: {integrity: sha512-Y4Ri62PfavhLQhFbqucysHOmRamlTVK10zPWlqjNbj2XMea+BOs4w6ASKwQwAiqf9ZqcY9Ab7NOU4wIgpxwoSQ==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -250,8 +250,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x/0.16.17:
-    resolution: {integrity: sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==}
+  /@esbuild/linux-s390x/0.17.6:
+    resolution: {integrity: sha512-SPUiz4fDbnNEm3JSdUW8pBJ/vkop3M1YwZAVwvdwlFLoJwKEZ9L98l3tzeyMzq27CyepDQ3Qgoba44StgbiN5Q==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -259,8 +259,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64/0.16.17:
-    resolution: {integrity: sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==}
+  /@esbuild/linux-x64/0.17.6:
+    resolution: {integrity: sha512-a3yHLmOodHrzuNgdpB7peFGPx1iJ2x6m+uDvhP2CKdr2CwOaqEFMeSqYAHU7hG+RjCq8r2NFujcd/YsEsFgTGw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -268,8 +268,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64/0.16.17:
-    resolution: {integrity: sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==}
+  /@esbuild/netbsd-x64/0.17.6:
+    resolution: {integrity: sha512-EanJqcU/4uZIBreTrnbnre2DXgXSa+Gjap7ifRfllpmyAU7YMvaXmljdArptTHmjrkkKm9BK6GH5D5Yo+p6y5A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -277,8 +277,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64/0.16.17:
-    resolution: {integrity: sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==}
+  /@esbuild/openbsd-x64/0.17.6:
+    resolution: {integrity: sha512-xaxeSunhQRsTNGFanoOkkLtnmMn5QbA0qBhNet/XLVsc+OVkpIWPHcr3zTW2gxVU5YOHFbIHR9ODuaUdNza2Vw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -286,8 +286,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64/0.16.17:
-    resolution: {integrity: sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==}
+  /@esbuild/sunos-x64/0.17.6:
+    resolution: {integrity: sha512-gnMnMPg5pfMkZvhHee21KbKdc6W3GR8/JuE0Da1kjwpK6oiFU3nqfHuVPgUX2rsOx9N2SadSQTIYV1CIjYG+xw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -295,8 +295,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64/0.16.17:
-    resolution: {integrity: sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==}
+  /@esbuild/win32-arm64/0.17.6:
+    resolution: {integrity: sha512-G95n7vP1UnGJPsVdKXllAJPtqjMvFYbN20e8RK8LVLhlTiSOH1sd7+Gt7rm70xiG+I5tM58nYgwWrLs6I1jHqg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -304,8 +304,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32/0.16.17:
-    resolution: {integrity: sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==}
+  /@esbuild/win32-ia32/0.17.6:
+    resolution: {integrity: sha512-96yEFzLhq5bv9jJo5JhTs1gI+1cKQ83cUpyxHuGqXVwQtY5Eq54ZEsKs8veKtiKwlrNimtckHEkj4mRh4pPjsg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -313,8 +313,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64/0.16.17:
-    resolution: {integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==}
+  /@esbuild/win32-x64/0.17.6:
+    resolution: {integrity: sha512-n6d8MOyUrNp6G4VSpRcgjs5xj4A91svJSaiwLIDWVWEsZtpN5FA9NlBbZHDmAJc2e8e6SF4tkBD3HAvPF+7igA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -1215,7 +1215,7 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-minify-templates/0.10.0_esbuild@0.16.17:
+  /esbuild-minify-templates/0.10.0_esbuild@0.17.6:
     resolution: {integrity: sha512-VEDDgKwRsHVeL/VbJXaoA6heccsvb48iGg4mG2jY/oA+j5ohtaQ/Klm556F7JlbN/L79YovTEPbCffLL/sr83g==}
     engines: {node: '>= 12'}
     peerDependencies:
@@ -1223,7 +1223,7 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.2.0
       astray: 1.1.1
-      esbuild: 0.16.17
+      esbuild: 0.17.6
       magic-string: 0.27.0
       meriyah: 4.3.3
     dev: true
@@ -1312,34 +1312,34 @@ packages:
       esbuild-windows-arm64: 0.15.18
     dev: true
 
-  /esbuild/0.16.17:
-    resolution: {integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==}
+  /esbuild/0.17.6:
+    resolution: {integrity: sha512-TKFRp9TxrJDdRWfSsSERKEovm6v30iHnrjlcGhLBOtReE28Yp1VSBRfO3GTaOFMoxsNerx4TjrhzSuma9ha83Q==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.16.17
-      '@esbuild/android-arm64': 0.16.17
-      '@esbuild/android-x64': 0.16.17
-      '@esbuild/darwin-arm64': 0.16.17
-      '@esbuild/darwin-x64': 0.16.17
-      '@esbuild/freebsd-arm64': 0.16.17
-      '@esbuild/freebsd-x64': 0.16.17
-      '@esbuild/linux-arm': 0.16.17
-      '@esbuild/linux-arm64': 0.16.17
-      '@esbuild/linux-ia32': 0.16.17
-      '@esbuild/linux-loong64': 0.16.17
-      '@esbuild/linux-mips64el': 0.16.17
-      '@esbuild/linux-ppc64': 0.16.17
-      '@esbuild/linux-riscv64': 0.16.17
-      '@esbuild/linux-s390x': 0.16.17
-      '@esbuild/linux-x64': 0.16.17
-      '@esbuild/netbsd-x64': 0.16.17
-      '@esbuild/openbsd-x64': 0.16.17
-      '@esbuild/sunos-x64': 0.16.17
-      '@esbuild/win32-arm64': 0.16.17
-      '@esbuild/win32-ia32': 0.16.17
-      '@esbuild/win32-x64': 0.16.17
+      '@esbuild/android-arm': 0.17.6
+      '@esbuild/android-arm64': 0.17.6
+      '@esbuild/android-x64': 0.17.6
+      '@esbuild/darwin-arm64': 0.17.6
+      '@esbuild/darwin-x64': 0.17.6
+      '@esbuild/freebsd-arm64': 0.17.6
+      '@esbuild/freebsd-x64': 0.17.6
+      '@esbuild/linux-arm': 0.17.6
+      '@esbuild/linux-arm64': 0.17.6
+      '@esbuild/linux-ia32': 0.17.6
+      '@esbuild/linux-loong64': 0.17.6
+      '@esbuild/linux-mips64el': 0.17.6
+      '@esbuild/linux-ppc64': 0.17.6
+      '@esbuild/linux-riscv64': 0.17.6
+      '@esbuild/linux-s390x': 0.17.6
+      '@esbuild/linux-x64': 0.17.6
+      '@esbuild/netbsd-x64': 0.17.6
+      '@esbuild/openbsd-x64': 0.17.6
+      '@esbuild/sunos-x64': 0.17.6
+      '@esbuild/win32-arm64': 0.17.6
+      '@esbuild/win32-ia32': 0.17.6
+      '@esbuild/win32-x64': 0.17.6
     dev: true
 
   /escalade/3.1.1:


### PR DESCRIPTION
- Update esbuild package
- Use new esbuild watch API
- Reorder execution in build; esbuild now runs last (otherwise watch prevents execution of things after)
- Fix CSS compile warnings when line or column number is 0
- Increase minimum chrome version build target to v110
- Move themes file generation logic into dedicated function for better code readability
- Ensure `dist` directory already exists for dev builds