### PR TITLE
feat: Refactor bookmark folder loading

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -30,7 +30,7 @@ function setupMocks(): void {
   global.chrome = {
     // @ts-expect-error - partial mock
     bookmarks: {
-      getTree: noopAsyncArr,
+      getChildren: noopAsyncArr,
       search: noopAsyncArr,
     },
     // @ts-expect-error - partial mock
@@ -85,6 +85,11 @@ function setupMocks(): void {
       update: noopAsync,
     },
   };
+
+  // global.fetch = () =>
+  //   Promise.resolve({
+  //     json: () => Promise.resolve({}),
+  //   } as Response);
 }
 
 export function reset(): void {

--- a/test/unit/newtab.test.ts
+++ b/test/unit/newtab.test.ts
@@ -1,6 +1,11 @@
-import { afterAll, expect, test } from 'bun:test';
+import { afterAll, beforeAll, expect, test } from 'bun:test';
 import { reset } from '../setup';
 import { consoleSpy } from './utils';
+
+beforeAll(() => {
+  // Workaround for hack in src/BookmarkBar.ts that waits for styles to be loaded
+  document.head.appendChild(document.createElement('style'));
+});
 
 afterAll(reset);
 


### PR DESCRIPTION
- Only load the bookmark node children when requested, rather than getting the entire tree upfront which was wasteful of memory resources and was possibly slower when the entire tree is extremely large
- Implement much better way to detect a bookmark folder is nested (not top level)