### PR TITLE
feat: Refactor tab link click handler & golfing

### DIFF
--- a/src/newtab.ts
+++ b/src/newtab.ts
@@ -1,3 +1,4 @@
+// Theme loader code must run first
 import './theme';
 
 import { append, createFragment } from 'stage1/runtime';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,8 +14,8 @@ export const DEFAULT_SECTION_ORDER = [
 // Simplified synthetic click event implementation of setupSyntheticEvent() from
 // stage1, plus special handling for browser internal links (e.g. chrome://)
 // https://github.com/maxmilton/stage1/blob/master/src/events.ts
-// eslint-disable-next-line consistent-return
-export const handleClick = (event: MouseEvent): void => {
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type, consistent-return
+export const handleClick = (event: MouseEvent): void | false => {
   let node = event.target as
     | (Node & { __click?(event: MouseEvent): void })
     | null;
@@ -32,8 +32,6 @@ export const handleClick = (event: MouseEvent): void => {
 
   // Only apply special handling to non-http links
   if (url?.[0] !== 'h') {
-    event.preventDefault();
-
     // if (link.target === '_blank' || event.ctrlKey) {
     if (event.ctrlKey) {
       // Open the location in a new tab
@@ -42,5 +40,8 @@ export const handleClick = (event: MouseEvent): void => {
       // Update the location in the current tab
       void chrome.tabs.update({ url });
     }
+
+    // Prevent default behaviour; shorter than `event.preventDefault()`
+    return false;
   }
 };

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -28,13 +28,22 @@ describe('DEFAULT_SECTION_ORDER', () => {
 // TODO: Add invarient tests for handleClick
 
 describe('handleClick', () => {
-  test('default prevented on event when url does not start with "h"', () => {
+  // test.skip('default prevented on event when url does not start with "h"', () => {
+  //   const event = new window.MouseEvent('click');
+  //   // @ts-expect-error - _target is an implementation detail of happy-dom
+  //   event._target = { href: 'chrome://about' };
+  //   expect(event.defaultPrevented).toBe(false);
+  //   handleClick(event);
+  //   expect(event.defaultPrevented).toBe(true);
+  // });
+
+  // returning false on click events is similar to event.preventDefault()
+  test('handler returns false when url does not start with "h"', () => {
     const event = new window.MouseEvent('click');
     // @ts-expect-error - _target is an implementation detail of happy-dom
     event._target = { href: 'chrome://about' };
-    expect(event.defaultPrevented).toBe(false);
-    handleClick(event);
-    expect(event.defaultPrevented).toBe(true);
+    const result = handleClick(event);
+    expect(result).toBe(false);
   });
 
   test('default not prevent on event when url starts with "h"', () => {


### PR DESCRIPTION
Fixes #2080

- Prevent closing the current page when clicking on the active "New Tab" page tab link
- Golf code to reduce final JS file size
- Rename some things for better clarity and/or to enable mangling